### PR TITLE
Update members' vision sentences (#148)

### DIFF
--- a/src/js/components/aboutUs/MeetOurTeam.js
+++ b/src/js/components/aboutUs/MeetOurTeam.js
@@ -153,7 +153,6 @@ const MeetOurTeam = ({ t }) => {
           <MemberImage src={austin}></MemberImage>
           <MemberName>Austin Zhu</MemberName>
           <MemberPosition>Project Co-leader</MemberPosition>
-          <MemberVision></MemberVision>
           <SocialMediaArea>
             <a
               href="https://www.instagram.com/austinzhu123/"
@@ -180,6 +179,7 @@ const MeetOurTeam = ({ t }) => {
                             <MediaIcon src={wechat}></MediaIcon>
                         </a> */}
           </SocialMediaArea>
+          <MemberVision>WasedaTime is gonna be legendary.</MemberVision>
         </Card>
 
         {/* ----------------------------------Mei */}
@@ -376,7 +376,6 @@ const MeetOurTeam = ({ t }) => {
           <MemberImage src={hatori}></MemberImage>
           <MemberName>Zhen Chao</MemberName>
           <MemberPosition>Frontend Engineer</MemberPosition>
-          <MemberVision></MemberVision>
           <SocialMediaArea>
             <a
               href="https://www.linkedin.com/in/%E8%87%BB-%E6%9B%B9-771718186/"
@@ -393,7 +392,7 @@ const MeetOurTeam = ({ t }) => {
               <MediaIcon src={facebook}></MediaIcon>
             </a>
           </SocialMediaArea>
-          <MemberVision>いまが最高！</MemberVision>
+          <MemberVision>{t("aboutus.seize the day")}</MemberVision>
         </Card>
 
         {/* ----------------------------------yaoyuan */}

--- a/src/js/data/locales/en/translation.json
+++ b/src/js/data/locales/en/translation.json
@@ -374,7 +374,8 @@
     "Kaiqing": "Kaiqing",
     "Yeping Tang": "Yeping Tang",
 
-    "Impressive I'm beginning to understand everything now":"Impressive, I'm beginning to understand everything now."
+    "Impressive I'm beginning to understand everything now":"Impressive, I'm beginning to understand everything now.",
+    "seize the day":"Seize the day!"
 
 
   }

--- a/src/js/data/locales/jp/translation.json
+++ b/src/js/data/locales/jp/translation.json
@@ -378,6 +378,6 @@
     "Kaiqing": "晴",
     "Yeping Tang": "トウ  ナリヒラ ",
     
-    "":""
+    "seize the day": "いまが最高！"
   }
 }


### PR DESCRIPTION
* log sw registration

* laod single course if school syllabus not exists in local

* Feature/about us gu (#136)

* 20201229 2210

* Attempt to improve font-size of tabs

* put tabs in at center

* adjust tabs' size

* our mission content

* our mission content v1

* ourmission image

* our mission page content

* our member page

* our member page

* our team content

* members page

* members page flex

* wechat icon

* add more members

* translation

* translation

* fix header bug

* more members

* 111

* fix translation error

* for first deploy

* Move files to aboutUs folder; remove unused variables

Co-authored-by: Hu Yong Hao <mlapenang1998@gmail.com>

* Remove unused pic

* Adjust mobile nav to display AboutUs link properly

* remove unused var

* skip waiting & reload after service worker got updated

* Remove explicit skipwaiting instruction

* Remove message listener from sw

* Recover listener for message from old swRegistration

* Update Hatori & Austin's vision sentences (#147)

Co-authored-by: JiaxianGu <43884711+JiaxianGu@users.noreply.github.com>