### PR TITLE
fix: remove a checked school but check still exist

### DIFF
--- a/syllabus/src/components/syllabus/SchoolFilterForm.tsx
+++ b/syllabus/src/components/syllabus/SchoolFilterForm.tsx
@@ -176,15 +176,18 @@ class SchoolFilterForm extends React.Component<Props, State> {
   };
 
   handleSchoolloading = async (school) => {
-    const { loadingSchool, loadedSchools } = this.state;
-    const oldestLoadedSchool = loadedSchools[0];
+    const { selectedSchools, loadSyllabus } = this.props;
+    const { loadedSchools } = this.state;
     let newLoadedSchools = [...loadedSchools];
-
-    if (loadedSchools.length >= 10) newLoadedSchools.splice(0, 1);
+    
+    if (loadedSchools.length >= 10) {
+      if (selectedSchools.includes(loadedSchools[0])) this.props.handleToggleFilter(loadedSchools[0]);
+      newLoadedSchools.splice(0, 1);
+    }
 
     this.setState({ loadingSchool: school });
     newLoadedSchools.push(school);
-    await this.props.loadSyllabus(school);
+    await loadSyllabus(school);
 
     this.setState(
       {

--- a/syllabus/src/redux/actions/index.ts
+++ b/syllabus/src/redux/actions/index.ts
@@ -83,7 +83,7 @@ export const fetchCourses = () => async (
   var updatedSchools = {};
   const schoolKeys = Object.keys(schools).filter((schoolKey) => {
     const exp = schools[schoolKey].exp;
-    return !exp || Date.parse(exp) <= Date.now();
+    return schools[schoolKey].active && (!exp || Date.parse(exp) <= Date.now());
   });
 
   if (schoolKeys.length === 0) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The syllabus of the oldest added school is automatically removed when a user adds more than 10 schools.
However, when the oldest school is checked, even after it is removed, the check still exists.
This hotfix aims at solving this bug.

## Description
<!--- Describe your changes in detail -->
When a user adds more than 10 schools in Syllabus, before removing the oldest school, uncheck that school if it is still checked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
