### PR TITLE
fix: add option -y back to preinstall script

### DIFF
--- a/campus/package.json
+++ b/campus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasedatime/campus",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "webpack serve --port 8081 --env isLocal",
     "start:standalone": "webpack serve --env standalone",
     "local": "concurrently --kill-others \"pnpm start\" \"cd ../root && pnpm start\"",

--- a/career/package.json
+++ b/career/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasedatime/career",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "webpack serve --port 8082 --env isLocal",
     "start:standalone": "webpack serve --env standalone",
     "local": "concurrently --kill-others \"pnpm start\" \"cd ../root && pnpm start\"",

--- a/feeds/package.json
+++ b/feeds/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "next dev --port 8083",
     "build": "APP_ENV=production next build && next export -o dist/",
     "build-dev": "APP_ENV=staging next build && next export -o dist/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasedatime/web",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "pnpm recursive run start --workspace-concurrency 6",
     "build": "pnpm recursive run build --workspace-concurrency 6",
     "build-dev": "pnpm recursive run build-dev --workspace-concurrency 6",

--- a/root/package.json
+++ b/root/package.json
@@ -4,7 +4,7 @@
     "*.css"
   ],
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "pnpm run tailwind:build && webpack serve --port 9000 --env isLocal",
     "fix": "pnpm run format && pnpm run lint:fix",
     "lint": "eslint src --ext \"**/*.{js,ts,tsx}\"",

--- a/syllabus/package.json
+++ b/syllabus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wasedatime/syllabus",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx -y only-allow pnpm",
     "start": "webpack serve --port 8080 --env isLocal",
     "start:standalone": "webpack serve --env standalone",
     "local": "concurrently --kill-others \"pnpm start\" \"cd ../root && pnpm start\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add option -y back to preinstall script
**Don't release this commit for now!**

## Description
<!--- Describe your changes in detail -->
Since currently `npm` on Amplify is at an older version, using option `-y` in the preinstall script causes error.
In the latest release, `-y` is removed from the preinstall script.
This commit added `-y` back in order to be consistent with the document & our members' develop environment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
