### PR TITLE
Feature: Remove bit from npmrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,43 +73,6 @@ sudo npm install -g pnpm
 ```
 Installation with other ways: https://pnpm.io/installation
 
-### Bit
-
-1. Create a [Bit.dev](https://bit.dev) account if you haven't.
-2. If you are a member of our development team, tell me your username or email so that I can add you to our Bit team.
-
-3. Then install Bit on your computer (local): https://docs.bit.dev/docs/installation
-
-4. Login to Bit on your terminal
-```
-bit login
-```
-
-5. Check your Bit authentication token with the following command:
-	```
-	bit config
-	```
-	and add the token to your environment variable with the following steps:
-
-	**Mac/Linux**
-	1. Add the following to file `~/.bash_profile`
-	```
-	export BIT_TOKEN=XXXXXXXXXXXXX
-	// replace XXXXXXXXXXXXX to your token
-	```
-	2. If you are using Z shell (check if there is a text `zsh` on top of your terminal), add the following in file `~/.zshrc`
-	```
-	if [ -f ~/.bash_profile ]; then 
-	    . ~/.bash_profile;
-	fi
-	```
-	3. Either restart your terminal or run the following:
-	```
-	source ~/.bash_profile
-	```
-	**Windows**
-	https://www3.ntu.edu.sg/home/ehchua/programming/howto/Environment_Variables.html
-
 ### Clone WasedaTime
 ```
 // By HTTP

--- a/apps/campus/.npmrc
+++ b/apps/campus/.npmrc
@@ -1,4 +1,2 @@
-@bit:registry=https://node.bit.dev
-//node.bit.dev/:_authToken=${BIT_TOKEN}
 always-auth=true
 recursive-install=false

--- a/apps/career/.npmrc
+++ b/apps/career/.npmrc
@@ -1,4 +1,2 @@
-@bit:registry=https://node.bit.dev
-//node.bit.dev/:_authToken=${BIT_TOKEN}
 always-auth=true
 recursive-install=false

--- a/apps/feeds/.npmrc
+++ b/apps/feeds/.npmrc
@@ -1,4 +1,2 @@
-@bit:registry=https://node.bit.dev
-//node.bit.dev/:_authToken=${BIT_TOKEN}
 always-auth=true
 recursive-install=false

--- a/apps/root/.npmrc
+++ b/apps/root/.npmrc
@@ -1,4 +1,2 @@
-@bit:registry=https://node.bit.dev
-//node.bit.dev/:_authToken=${BIT_TOKEN}
 always-auth=true
 recursive-install=false

--- a/apps/syllabus/.npmrc
+++ b/apps/syllabus/.npmrc
@@ -1,4 +1,2 @@
-@bit:registry=https://node.bit.dev
-//node.bit.dev/:_authToken=${BIT_TOKEN}
 always-auth=true
 recursive-install=false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed some more lines of code that depends on bit token login 

## Description
<!--- Describe your changes in detail -->

Removed the need for Bit token in the npmrc file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After checking once more whether new developers can easily start developing or not, there are still some dependencies found that use Bit login. We would need to remove these to not produce any errors when running the very first installation

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran the `pnpm i` command from a new device after cloning the repo, and found some errors related to bit when i did not have the bit env files in the repo.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
